### PR TITLE
Improve interface and complete modules

### DIFF
--- a/kratorstrike.py
+++ b/kratorstrike.py
@@ -8,11 +8,11 @@ from rich.prompt import Prompt
 
 from modules import ascii_banner
 
+Path('logs').mkdir(exist_ok=True)
 logging.basicConfig(filename='logs/session.log', level=logging.INFO,
                     format='%(asctime)s - %(levelname)s - %(message)s')
 
 console = Console()
-Path('logs').mkdir(exist_ok=True)
 
 MODULES = {
     '1': ('Passive Recon', 'recon_passive'),
@@ -41,6 +41,7 @@ def main():
     except Exception as e:
         logging.error(f"Failed to display banner: {e}")
     while True:
+        console.clear()
         table = Table(title="KratorStrike")
         table.add_column("Option")
         table.add_column("Module")
@@ -60,6 +61,7 @@ def main():
             logging.info(f"Launching module: {name}")
             mod = importlib.import_module(f"modules.{mod_name}")
             mod.run()
+            Prompt.ask("Press Enter to return to menu")
         except Exception as e:
             logging.error(f"Error running {name}: {e}")
             console.print(f"[red]Error running {name}: {e}[/red]")

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,13 @@
+"""KratorStrike modules package."""
+
+__all__ = [
+    'ascii_banner',
+    'recon_passive',
+    'recon_active',
+    'brute_force',
+    'visual_recon',
+    'ai_analyst',
+    'plugin_loader',
+    'report_gen',
+    'self_updater',
+]

--- a/modules/ascii_banner.py
+++ b/modules/ascii_banner.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 from datetime import datetime
@@ -7,6 +6,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.panel import Panel
 from rich.live import Live
+from pyfiglet import figlet_format
 
 console = Console()
 try:
@@ -16,13 +16,9 @@ except Exception:
 OUTPUT_DIR = Path('output/banner')
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-BANNER = r"""
- _  __          _             
-| |/ /_ __ __ _| |_ ___  _ __ 
-| ' /| '__/ _` | __/ _ \| '__|
-| . \| | | (_| | || (_) | |   
-|_|\_\_|  \__,_|\__\___/|_|   
-"""
+def generate_banner() -> str:
+    """Return ASCII art banner text."""
+    return figlet_format("KratorStrike", font="slant")
 
 
 # required input() function
@@ -45,14 +41,16 @@ def print_summary():
 
 
 def run():
+    """Render the animated banner."""
     console.clear()
+    banner = generate_banner()
     captured = ""
     with Live(console=console, refresh_per_second=4) as live:
         rendered = ""
-        for line in BANNER.splitlines():
+        for line in banner.splitlines():
             rendered += line + "\n"
             live.update(Panel(rendered, title=f"Krator v{VERSION}", border_style="red"))
-            time.sleep(0.2)
+            time.sleep(0.1)
         captured = rendered
     status_panel = Panel(f"Version: {VERSION}\nStatus: Ready", title="Status", style="green")
     console.print(status_panel)

--- a/modules/plugin_loader.py
+++ b/modules/plugin_loader.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import logging
 from pathlib import Path
+from datetime import datetime
 
 from rich.console import Console
 from rich.prompt import Prompt
@@ -10,26 +11,37 @@ from rich.table import Table
 console = Console()
 PLUG_DIR = Path('plugins')
 PLUG_DIR.mkdir(exist_ok=True)
+OUTPUT_DIR = Path('output/plugins')
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def list_plugins():
     return [f for f in PLUG_DIR.iterdir() if f.suffix in ('.py', '.sh')]
 
 
-def run_plugin(path: Path):
+def run_plugin(path: Path) -> str:
+    """Execute a plugin and return its output."""
     logging.info(f'Running plugin {path}')
     try:
         if path.suffix == '.py':
-            subprocess.run(['python3', str(path)], check=True)
+            result = subprocess.run(['python3', str(path)], capture_output=True, text=True, check=True)
         elif path.suffix == '.sh':
-            subprocess.run(['bash', str(path)], check=True)
+            result = subprocess.run(['bash', str(path)], capture_output=True, text=True, check=True)
+        else:
+            return ''
+        return result.stdout + result.stderr
     except subprocess.CalledProcessError as e:
         console.print(f'[red]Plugin {path} failed: {e}[/red]')
         logging.error(f'Plugin {path} failed: {e}')
+        return str(e)
 
 
-def save_output(_target, _data):
-    pass
+def save_output(target: str, data: str) -> None:
+    """Persist plugin output to a timestamped file."""
+    filename = OUTPUT_DIR / f"{target}_{datetime.now().strftime('%Y%m%d%H%M%S')}.log"
+    with open(filename, 'w') as f:
+        f.write(data)
+    logging.info(f'Plugin output saved to {filename}')
 
 
 def print_summary():
@@ -56,6 +68,7 @@ def run():
     except ValueError:
         console.print('[red]Invalid selection[/red]')
         return
-    run_plugin(plugins[idx])
+    output = run_plugin(plugins[idx])
+    save_output(plugins[idx].stem, output)
     print_summary()
     console.print('[green]Plugin execution completed[/green]')

--- a/modules/self_updater.py
+++ b/modules/self_updater.py
@@ -1,12 +1,19 @@
 import subprocess
+from datetime import datetime
 from pathlib import Path
 from rich.console import Console
 
 console = Console()
+OUTPUT_DIR = Path('output/updater')
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def save_output(_t, _d):
-    pass
+def save_output(target: str, data: str) -> None:
+    """Save updater output to a timestamped file."""
+    filename = OUTPUT_DIR / f"{target}_{datetime.now().strftime('%Y%m%d%H%M%S')}.log"
+    with open(filename, 'w') as f:
+        f.write(data)
+    console.log(f'Update output saved to {filename}')
 
 
 def print_summary():
@@ -17,8 +24,10 @@ def run():
     console.print('[bold cyan]Self Updater[/bold cyan]')
     repo = Path(__file__).resolve().parent.parent
     try:
-        subprocess.run(['git', '-C', str(repo), 'pull'], check=True)
+        result = subprocess.run(['git', '-C', str(repo), 'pull'], capture_output=True, text=True, check=True)
         console.print('[green]Repository updated[/green]')
-    except subprocess.CalledProcessError:
+        save_output('update', result.stdout + result.stderr)
+    except subprocess.CalledProcessError as e:
         console.print('[red]Update failed[/red]')
+        save_output('update_error', e.stderr if hasattr(e, 'stderr') else str(e))
     print_summary()


### PR DESCRIPTION
## Summary
- polish the startup banner with `pyfiglet`
- capture plugin output and save logs
- record results of update operations
- expose available modules via `__all__`
- clear menu between runs and pause after modules
- create `logs` directory before configuring logging

## Testing
- `python3 -m py_compile modules/*.py kratorstrike.py`

------
https://chatgpt.com/codex/tasks/task_e_6850b6c38ea08328813b577155d04c5b